### PR TITLE
don't default to first list

### DIFF
--- a/lib/subsequent/state.rb
+++ b/lib/subsequent/state.rb
@@ -6,7 +6,6 @@ Subsequent::State =
     def self.format(cards:, sort:)
       card = sort.call(cards)
       checklist = card.checklists.find(&:unchecked_items?)
-      checklist ||= card.checklists.first
       checklist ||= Subsequent::Models::NullChecklist.new
       checklist_items = checklist.unchecked_items.first(5)
       mode = Subsequent::Mode::Normal

--- a/spec/support/coverage.rb
+++ b/spec/support/coverage.rb
@@ -10,4 +10,4 @@ SimpleCov.start do
   add_group "Support", "spec/support"
 end
 
-SimpleCov.minimum_coverage(line: 97, branch: 80)
+SimpleCov.minimum_coverage(line: 97, branch: 83)


### PR DESCRIPTION
We still use the created list when a new one is added, but it doesn't
necessarily make sense to select an arbitrary list when none have items.
